### PR TITLE
Fixes readme for removal of listener; Updates readme with manual install example

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ _setOrientation(deviceOrientation, applicationOrientation, device, size) {
    console.log(deviceOrientation, applicationOrientation, device, size);
 },
 componentDidMount(){
-  Orientation.addListener(this._setOrientation);
+  this.orientationListener = Orientation.addListener(this._setOrientation);
 }
 ```
 
@@ -64,7 +64,7 @@ This method removes the listener you added in componentDidMount:
 
 ```javascript
 componentWillUnmount() {
-  Orientation.removeListener(this._setOrientation);
+  this.orientationListener.remove(); 
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,48 @@ This library is a fork of [this library by Ken Wheeler](https://github.com/walma
 - `npm install -g rnpm`
 - `rnpm link react-native-orientation-controller`
 
-###Usage
+### Or Manual Installation
+
+#### Android
+
+Add to `android/settings.gradle`:
+
+```
+include ':react-native-orientation-controller'
+project(':react-native-orientation-controller').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-orientation-controller/android')
+```
+
+Add the compile project line to `android/app/build.gradle` (inside `dependencies`):
+
+```
+dependencies {
+    // ... other content ... 
+    compile project(':react-native-orientation-controller')
+}
+```
+
+Inside `MainActivity.java` (normally somewhere here `android/app/src/main/java/com/<your-app-name>/MainActivity.java`)
+add `import com.inprogress.ReactOrientationController.ReactOrientationController;` and ` new ReactOrientationController(this)`
+like in the example below
+
+```
+import com.inprogress.ReactOrientationController.ReactOrientationController; // <<< ADD THIS
+
+/* ... other content ... */
+
+    @Override
+    protected List<ReactPackage> getPackages() {
+        return Arrays.<ReactPackage>asList(
+            new MainReactPackage(),
+            new ReactOrientationController(this) // <<< AND THIS
+            /* ... other packages can be here ... */
+        );
+    }
+
+```
+
+
+### Usage
 
 Import the library:
 


### PR DESCRIPTION
The `Orientation.removeListener` was throwing 

```
undefined is not a function (evaluating 'DeviceEventEmitter.removeListener('orientationDidChange',listener)')
```

It seems that readme has outdated or wrong example. On the other hand, using it in a way that is described here works:
https://github.com/walmartreact/react-native-orientation-listener/issues/6

I've tested it for this fork and it works for this fork as well.

Also, I had troubles linking with `rnpm`, so I had to link manually. Not sure if this is the issue on my side or with the library, so I updated the README with a manual installation in case people will want to link manually, so that they can just copy paste. 

Btw, thanks for this putting this library fork on github!
